### PR TITLE
EDX-6955 Fix ScanDeviceRequest sending empty profile name to XRT

### DIFF
--- a/pkg/xrtmodels/request.go
+++ b/pkg/xrtmodels/request.go
@@ -75,7 +75,7 @@ type DiscoveredDeviceInfo struct {
 type ScanDeviceRequest struct {
 	BaseRequest `json:",inline"`
 	DeviceName  string         `json:"device"`
-	ProfileName string         `json:"profile"`
+	ProfileName string         `json:"profile,omitempty"`
 	Options     map[string]any `json:"options"`
 }
 

--- a/pkg/xrtmodels/request_test.go
+++ b/pkg/xrtmodels/request_test.go
@@ -70,3 +70,35 @@ func TestNewRequest(t *testing.T) {
 		})
 	}
 }
+
+func TestNewDeviceScanRequest_OmitEmptyProfileName(t *testing.T) {
+	device := DeviceInfo{}
+	request := NewDeviceScanRequest(device, "testClient", nil)
+
+	data, err := json.Marshal(request)
+	require.NoError(t, err)
+
+	var raw map[string]any
+	err = json.Unmarshal(data, &raw)
+	require.NoError(t, err)
+
+	_, hasProfile := raw["profile"]
+	assert.False(t, hasProfile, "profile field should be omitted when ProfileName is empty")
+}
+
+func TestNewDeviceScanRequest_IncludeProfileName(t *testing.T) {
+	device := DeviceInfo{}
+	device.ProfileName = "my-profile"
+	request := NewDeviceScanRequest(device, "testClient", nil)
+
+	data, err := json.Marshal(request)
+	require.NoError(t, err)
+
+	var raw map[string]any
+	err = json.Unmarshal(data, &raw)
+	require.NoError(t, err)
+
+	profileVal, hasProfile := raw["profile"]
+	assert.True(t, hasProfile, "profile field should be present when ProfileName is set")
+	assert.Equal(t, "my-profile", profileVal)
+}


### PR DESCRIPTION
ScanDeviceRequest.ProfileName was serialized as `profile": "` even when no profile name was intended, because the json tag lacked omitempty. 
[XRT](https://github.com/IOTechSystems/xrt/blob/v2.2-branch/src/c/devsdk/service.c#L3321) treats an empty string as a provided profile name, which on first scan creates a profile keyed by "" and on subsequent scans returns "profile already exists" error. 

Adding omitempty ensures the field is omitted when empty, so XRT follows the compare-and-update-if-different path instead.