### PR TITLE
EDX-7110 Using limit=-1 to query all alarm configs

### DIFF
--- a/pkg/clients/http/alarm.go
+++ b/pkg/clients/http/alarm.go
@@ -15,7 +15,8 @@ import (
 	"github.com/edgexfoundry/go-mod-core-contracts/v4/errors"
 )
 
-const defaultMaxLimit = "100"
+// unlimitedLimit tells support-alarm to return all items (no maximum).
+const unlimitedLimit = "-1"
 
 // AlarmClient encapsulates HTTP operations against the support-alarm service.
 type AlarmClient struct {
@@ -180,7 +181,7 @@ func (c *AlarmClient) AddRoute(ctx context.Context, data []byte) errors.EdgeX {
 func (c *AlarmClient) queryAll(ctx context.Context, apiRoute string) (map[string]any, errors.EdgeX) {
 	params := url.Values{}
 	params.Set(pkgCommon.Offset, "0")
-	params.Set(pkgCommon.Limit, defaultMaxLimit) // TODO use -1 if the alarm service supports it
+	params.Set(pkgCommon.Limit, unlimitedLimit)
 	var res map[string]any
 	err := utils.GetRequest(ctx, &res, c.baseUrl, apiRoute, params, c.authInjector)
 	if err != nil {

--- a/pkg/clients/http/alarm_test.go
+++ b/pkg/clients/http/alarm_test.go
@@ -1,0 +1,36 @@
+// Copyright (C) 2026 IOTech Ltd
+
+package http
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	pkgCommon "github.com/IOTechSystems/go-mod-central-ext/v4/pkg/common"
+)
+
+// TestAlarmClient_queryAll_RequestsAllItems verifies that the "list all" path
+// (here exercised via AllTemplates) asks support-alarm for every item by sending
+// offset=0&limit=-1, rather than a capped page size.
+func TestAlarmClient_queryAll_RequestsAllItems(t *testing.T) {
+	var gotOffset, gotLimit string
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotOffset = r.URL.Query().Get(pkgCommon.Offset)
+		gotLimit = r.URL.Query().Get(pkgCommon.Limit)
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(map[string]any{pkgCommon.AlarmJsonKeyTemplates: []any{}})
+	}))
+	defer ts.Close()
+
+	client := NewAlarmClient(ts.URL, NewNullAuthenticationInjector(), false)
+	_, err := client.AllTemplates(context.Background())
+	require.NoError(t, err)
+
+	require.Equal(t, "0", gotOffset)
+	require.Equal(t, "-1", gotLimit)
+}


### PR DESCRIPTION
Update limit=-1 to match the API change of support-alarm