### PR TITLE
EDX-7257 Add XRT batch ops models

### DIFF
--- a/pkg/xrtmodels/deviceInfo.go
+++ b/pkg/xrtmodels/deviceInfo.go
@@ -15,6 +15,13 @@ import (
 
 type DeviceInfo struct {
 	edgexDtos.Device
+	// Operational reports whether XRT can currently reach the device. XRT sets it on
+	// device:read and device:read_batch; it is omitempty because ToXrtDevice builds
+	// outbound requests through this type, where the field has no meaning.
+	//
+	// This is distinct from the embedded OperatingState, which is EdgeX's own
+	// administrative view and is not populated by XRT.
+	Operational bool `json:"operational,omitempty"`
 }
 
 // ToEdgeXV2Device converts the XRT model to EdgeX v2 model

--- a/pkg/xrtmodels/deviceinfo_test.go
+++ b/pkg/xrtmodels/deviceinfo_test.go
@@ -3,9 +3,11 @@
 package xrtmodels
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/IOTechSystems/go-mod-central-ext/v4/pkg/common"
 	edgexDtos "github.com/edgexfoundry/go-mod-core-contracts/v4/dtos"
@@ -127,4 +129,39 @@ func TestToEdgeXV3Device(t *testing.T) {
 	assert.Equal(t, device.ServiceName, result.ServiceName)
 	assert.Equal(t, device.Protocols, result.Protocols)
 	assert.Equal(t, map[string]any{common.ProtocolName: "ble"}, result.Properties)
+}
+
+// XRT reports device reachability as "operational" on device:read and
+// device:read_batch. EdgeX has no such field — its OperatingState is an administrative
+// value XRT does not set — so DeviceInfo carries it separately.
+func TestDeviceInfoOperational(t *testing.T) {
+	// Captured from a device:read reply on XRT 3.4.6.
+	const reply = `{"name":"modbus-sim","operational":true,"profileName":"modbus-sim-profile",` +
+		`"protocols":{"modbus-tcp":{"Address":"172.17.0.4","Port":5020,"UnitID":1}}}`
+
+	t.Run("decodes the operational flag", func(t *testing.T) {
+		var device DeviceInfo
+		require.NoError(t, json.Unmarshal([]byte(reply), &device))
+
+		assert.True(t, device.Operational)
+		assert.Equal(t, "modbus-sim", device.Name)
+	})
+
+	t.Run("an unreachable device decodes as false", func(t *testing.T) {
+		var device DeviceInfo
+		require.NoError(t, json.Unmarshal([]byte(`{"name":"d","operational":false}`), &device))
+
+		assert.False(t, device.Operational)
+	})
+
+	// ToXrtDevice builds add and update requests through DeviceInfo, where the flag is
+	// meaningless — sending operational=false would state something XRT never asked for.
+	t.Run("outbound requests omit the flag", func(t *testing.T) {
+		device, err := ToXrtDevice(edgexDtos.Device{Name: "d", ProfileName: "p"})
+		require.NoError(t, err)
+
+		encoded, marshalErr := json.Marshal(device)
+		require.NoError(t, marshalErr)
+		assert.NotContains(t, string(encoded), "operational")
+	})
 }

--- a/pkg/xrtmodels/request.go
+++ b/pkg/xrtmodels/request.go
@@ -30,6 +30,14 @@ const (
 	ScheduleReadOperation   = "schedule:read"
 	ScheduleUpdateOperation = "schedule:update"
 
+	BatchReadDevicesOperation   = "device:read_batch"
+	BatchAddDevicesOperation    = "device:add_batch"
+	BatchDeleteDevicesOperation = "device:delete_batch"
+
+	BatchReadSchedulesOperation   = "schedule:read_batch"
+	BatchAddSchedulesOperation    = "schedule:add_batch"
+	BatchDeleteSchedulesOperation = "schedule:delete_batch"
+
 	DiscoveryTriggerOperation = "discovery:trigger"
 
 	ComponentUpdateOperation    = "component:update"
@@ -408,4 +416,130 @@ func NewDiscoveryRequest(clientName string, options map[string]interface{}) Disc
 		Options: options,
 	}
 	return req
+}
+
+// BatchReadDevicesRequest is the request body for device:read_batch. Both fields are
+// omitempty because an absent argument selects every device.
+type BatchReadDevicesRequest struct {
+	BaseRequest `json:",inline"`
+	Devices     []string `json:"devices,omitempty"`
+	Pattern     string   `json:"pattern,omitempty"`
+}
+
+// BatchDeleteDevicesRequest is the request body for device:delete_batch, which names its
+// targets: the specification offers neither a pattern nor a way to delete every device.
+type BatchDeleteDevicesRequest struct {
+	BaseRequest `json:",inline"`
+	Devices     []string `json:"devices"`
+}
+
+// BatchAddDevicesRequest repeats the shape of a single device:add.
+type BatchAddDevicesRequest struct {
+	BaseRequest `json:",inline"`
+	Devices     []BatchAddDeviceItem `json:"devices"`
+}
+
+// BatchAddDeviceItem is one device in a device:add_batch request, carrying the same
+// name/info pair a single device:add sends.
+type BatchAddDeviceItem struct {
+	DeviceName string     `json:"device"`
+	DeviceInfo DeviceInfo `json:"device_info"`
+}
+
+// NewBatchReadDevicesRequest builds a device:read_batch request. The specification makes
+// the argument a one-of; this constructor does not validate the selector, so callers must
+// leave devices and pattern empty to select everything and set at most one of them otherwise.
+func NewBatchReadDevicesRequest(deviceNames []string, pattern, clientName string) BatchReadDevicesRequest {
+	if deviceNames == nil {
+		deviceNames = []string{}
+	}
+	return BatchReadDevicesRequest{
+		BaseRequest: NewBaseRequest(BatchReadDevicesOperation, clientName),
+		Devices:     deviceNames,
+		Pattern:     pattern,
+	}
+}
+
+// NewBatchAddDevicesRequest builds a device:add_batch request. XRT expects each device as
+// a name/info pair; the name is taken from the device itself so the two cannot disagree.
+func NewBatchAddDevicesRequest(devices []DeviceInfo, clientName string) BatchAddDevicesRequest {
+	items := make([]BatchAddDeviceItem, 0, len(devices))
+	for _, device := range devices {
+		items = append(items, BatchAddDeviceItem{DeviceName: device.Name, DeviceInfo: device})
+	}
+	return BatchAddDevicesRequest{
+		BaseRequest: NewBaseRequest(BatchAddDevicesOperation, clientName),
+		Devices:     items,
+	}
+}
+
+// NewBatchDeleteDevicesRequest builds a device:delete_batch request.
+func NewBatchDeleteDevicesRequest(deviceNames []string, clientName string) BatchDeleteDevicesRequest {
+	if deviceNames == nil {
+		deviceNames = []string{}
+	}
+	return BatchDeleteDevicesRequest{
+		BaseRequest: NewBaseRequest(BatchDeleteDevicesOperation, clientName),
+		Devices:     deviceNames,
+	}
+}
+
+// BatchReadSchedulesRequest is the request body for schedule:read_batch. Every field is
+// omitempty because an absent argument selects every schedule.
+type BatchReadSchedulesRequest struct {
+	BaseRequest `json:",inline"`
+	Schedules   []string `json:"schedules,omitempty"`
+	Device      string   `json:"device,omitempty"`
+	Pattern     string   `json:"pattern,omitempty"`
+}
+
+// BatchDeleteSchedulesRequest is the request body for schedule:delete_batch. Set exactly
+// one of Schedules or Device: delete offers no pattern and no way to delete every schedule.
+type BatchDeleteSchedulesRequest struct {
+	BaseRequest `json:",inline"`
+	Schedules   []string `json:"schedules,omitempty"`
+	Device      string   `json:"device,omitempty"`
+}
+
+type BatchAddSchedulesRequest struct {
+	BaseRequest `json:",inline"`
+	Schedules   []Schedule `json:"schedules"`
+}
+
+// NewBatchReadSchedulesRequest builds a schedule:read_batch request. The specification makes
+// the argument a one-of; this constructor does not validate the selector, so callers must
+// leave all three empty to select everything and set at most one of them otherwise.
+func NewBatchReadSchedulesRequest(scheduleNames []string, deviceName, pattern, clientName string) BatchReadSchedulesRequest {
+	if scheduleNames == nil && deviceName == "" {
+		scheduleNames = []string{}
+	}
+	return BatchReadSchedulesRequest{
+		BaseRequest: NewBaseRequest(BatchReadSchedulesOperation, clientName),
+		Schedules:   scheduleNames,
+		Device:      deviceName,
+		Pattern:     pattern,
+	}
+}
+
+// NewBatchAddSchedulesRequest builds a schedule:add_batch request. An empty payload is
+// encoded as [] rather than null so both add operations put the same shape on the wire.
+func NewBatchAddSchedulesRequest(schedules []Schedule, clientName string) BatchAddSchedulesRequest {
+	items := make([]Schedule, 0, len(schedules))
+	items = append(items, schedules...)
+	return BatchAddSchedulesRequest{
+		BaseRequest: NewBaseRequest(BatchAddSchedulesOperation, clientName),
+		Schedules:   items,
+	}
+}
+
+// NewBatchDeleteSchedulesRequest builds a schedule:delete_batch request.
+func NewBatchDeleteSchedulesRequest(scheduleNames []string, deviceName, clientName string) BatchDeleteSchedulesRequest {
+	if scheduleNames == nil && deviceName == "" {
+		scheduleNames = []string{}
+	}
+	return BatchDeleteSchedulesRequest{
+		BaseRequest: NewBaseRequest(BatchDeleteSchedulesOperation, clientName),
+		Schedules:   scheduleNames,
+		Device:      deviceName,
+	}
 }

--- a/pkg/xrtmodels/request_test.go
+++ b/pkg/xrtmodels/request_test.go
@@ -4,6 +4,7 @@ package xrtmodels
 
 import (
 	"encoding/json"
+	"reflect"
 	"testing"
 
 	edgexDtos "github.com/edgexfoundry/go-mod-core-contracts/v4/dtos"
@@ -151,4 +152,145 @@ func TestNewScheduleUpdateRequest_ScheduleField(t *testing.T) {
 	data, err := json.Marshal(req)
 	require.NoError(t, err)
 	assert.Contains(t, string(data), `"sched1"`)
+}
+
+// The batch selector is one-of and every field is omitempty, because XRT treats a request
+// with no selector as "all" — a zero-valued field must not be sent as an empty selector.
+func TestNewBatchRequests(t *testing.T) {
+	const client = "test-client"
+
+	t.Run("read devices", func(t *testing.T) {
+		tests := []struct {
+			name    string
+			names   []string
+			pattern string
+			expect  map[string]any
+		}{
+			{"no argument selects all", nil, "", map[string]any{}},
+			{"by names", []string{"a", "b"}, "", map[string]any{"devices": []any{"a", "b"}}},
+			{"by pattern", nil, ".*", map[string]any{"pattern": ".*"}},
+		}
+		for _, tc := range tests {
+			t.Run(tc.name, func(t *testing.T) {
+				request := NewBatchReadDevicesRequest(tc.names, tc.pattern, client)
+				assertBatchRequest(t, request, request.BaseRequest, BatchReadDevicesOperation, tc.expect)
+			})
+		}
+	})
+
+	t.Run("delete devices", func(t *testing.T) {
+		request := NewBatchDeleteDevicesRequest([]string{"a"}, client)
+		assertBatchRequest(t, request, request.BaseRequest, BatchDeleteDevicesOperation,
+			map[string]any{"devices": []any{"a"}})
+	})
+
+	t.Run("read schedules", func(t *testing.T) {
+		request := NewBatchReadSchedulesRequest(nil, "dev-1", "", client)
+		assertBatchRequest(t, request, request.BaseRequest, BatchReadSchedulesOperation,
+			map[string]any{"device": "dev-1"})
+	})
+
+	// Delete offers no pattern and no "all", so the selector cannot express either.
+	t.Run("delete schedules by names", func(t *testing.T) {
+		request := NewBatchDeleteSchedulesRequest([]string{"s1"}, "", client)
+		assertBatchRequest(t, request, request.BaseRequest, BatchDeleteSchedulesOperation,
+			map[string]any{"schedules": []any{"s1"}})
+	})
+
+	t.Run("add requests carry their payload", func(t *testing.T) {
+		devices := NewBatchAddDevicesRequest([]DeviceInfo{{Device: edgexDtos.Device{Name: "a"}}}, client)
+		if devices.Op != BatchAddDevicesOperation || len(devices.Devices) != 1 {
+			t.Errorf("got %+v, want one device for %s", devices, BatchAddDevicesOperation)
+		}
+		schedules := NewBatchAddSchedulesRequest([]Schedule{{Name: "s1"}}, client)
+		if schedules.Op != BatchAddSchedulesOperation || len(schedules.Schedules) != 1 {
+			t.Errorf("got %+v, want one schedule for %s", schedules, BatchAddSchedulesOperation)
+		}
+	})
+}
+
+// assertBatchRequest checks the operation and that exactly the expected selector fields
+// are present on the wire. The request is taken as any so it serves both the device and
+// schedule request types.
+func assertBatchRequest(t *testing.T, request any, base BaseRequest, expectedOp string, expectedFields map[string]any) {
+	t.Helper()
+
+	if base.Op != expectedOp {
+		t.Errorf("op: got %q, want %q", base.Op, expectedOp)
+	}
+	if base.RequestId == "" || base.Client == "" {
+		t.Errorf("request must carry a client and request id, got %+v", base)
+	}
+
+	encoded, err := json.Marshal(request)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	var decoded map[string]any
+	if err := json.Unmarshal(encoded, &decoded); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	for _, field := range []string{"devices", "schedules", "device", "pattern"} {
+		got, present := decoded[field]
+		want, expected := expectedFields[field]
+		if expected != present {
+			t.Errorf("field %q: present=%v, want present=%v", field, present, expected)
+			continue
+		}
+		if expected && !reflect.DeepEqual(got, want) {
+			t.Errorf("field %q: got %v, want %v", field, got, want)
+		}
+	}
+}
+
+// The add_batch item name is derived from the device, so it cannot disagree with the
+// device info XRT receives alongside it.
+func TestNewBatchAddDevicesRequestDerivesTheName(t *testing.T) {
+	devices := []DeviceInfo{
+		{Device: edgexDtos.Device{Name: "dev-1", ProfileName: "p"}},
+		{Device: edgexDtos.Device{Name: "dev-2", ProfileName: "p"}},
+	}
+
+	request := NewBatchAddDevicesRequest(devices, "test-client")
+
+	if len(request.Devices) != len(devices) {
+		t.Fatalf("got %d items, want %d", len(request.Devices), len(devices))
+	}
+	for i, item := range request.Devices {
+		if item.DeviceName != devices[i].Name {
+			t.Errorf("[%d] name: got %q, want %q", i, item.DeviceName, devices[i].Name)
+		}
+		if item.DeviceInfo.Name != devices[i].Name {
+			t.Errorf("[%d] info name: got %q, want %q", i, item.DeviceInfo.Name, devices[i].Name)
+		}
+	}
+}
+
+// Both add operations must put the same shape on the wire for an empty payload; XRT does
+// not define whether null and [] are equivalent, so neither constructor should emit null.
+func TestBatchAddRequestsEncodeEmptyPayloadConsistently(t *testing.T) {
+	tests := []struct {
+		name    string
+		request any
+		field   string
+	}{
+		{"devices", NewBatchAddDevicesRequest(nil, "c"), "devices"},
+		{"schedules", NewBatchAddSchedulesRequest(nil, "c"), "schedules"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			encoded, err := json.Marshal(tc.request)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			var decoded map[string]json.RawMessage
+			if err := json.Unmarshal(encoded, &decoded); err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got := string(decoded[tc.field]); got != "[]" {
+				t.Errorf("%s: got %s, want []", tc.field, got)
+			}
+		})
+	}
 }

--- a/pkg/xrtmodels/response.go
+++ b/pkg/xrtmodels/response.go
@@ -165,3 +165,87 @@ type ComponentsDiscoveryResponse struct {
 	ServerID   string      `json:"server_id"`
 	Type       string      `json:"type"`
 }
+
+// BatchDevicesResponse is the reply to device:read_batch. Entries are null for devices
+// that do not exist, so the element type must be a pointer to keep the result aligned
+// with the requested names.
+type BatchDevicesResponse struct {
+	BaseResponse `json:",inline"`
+	Result       BatchDevicesResult `json:"result"`
+}
+
+type BatchDevicesResult struct {
+	BaseResult `json:",inline"`
+	Devices    []*DeviceInfo `json:"devices"`
+}
+
+// BatchDeviceResultsResponse is the reply to device:add_batch and device:delete_batch.
+type BatchDeviceResultsResponse struct {
+	BaseResponse `json:",inline"`
+	Result       BatchDeviceResults `json:"result"`
+}
+
+// BatchDeviceResults holds the per-item outcomes. The embedded status reports whether the
+// request was accepted and stays 0 when individual items fail.
+type BatchDeviceResults struct {
+	BaseResult `json:",inline"`
+	Results    []BatchDeviceResult `json:"device_results"`
+}
+
+type BatchDeviceResult struct {
+	BaseResult `json:",inline"`
+	Device     string `json:"device"`
+}
+
+// BatchSchedulesResponse is the reply to schedule:read_batch, shaped as
+// BatchDevicesResponse is.
+type BatchSchedulesResponse struct {
+	BaseResponse `json:",inline"`
+	Result       BatchSchedulesResult `json:"result"`
+}
+
+type BatchSchedulesResult struct {
+	BaseResult `json:",inline"`
+	Schedules  []*Schedule `json:"schedules"`
+}
+
+// BatchScheduleResultsResponse is the reply to schedule:add_batch and
+// schedule:delete_batch, with the same per-item reporting as the device operations.
+type BatchScheduleResultsResponse struct {
+	BaseResponse `json:",inline"`
+	Result       BatchScheduleResults `json:"result"`
+}
+
+// BatchScheduleResults holds the per-item outcomes, as BatchDeviceResults does.
+type BatchScheduleResults struct {
+	BaseResult `json:",inline"`
+	Results    []BatchScheduleResult `json:"schedule_results"`
+}
+
+type BatchScheduleResult struct {
+	BaseResult `json:",inline"`
+	Schedule   string `json:"schedule"`
+}
+
+// BatchItemResult is the outcome of one item in a batch operation. A nil error from the
+// call means the request was processed, not that every item succeeded.
+type BatchItemResult struct {
+	Name   string
+	Status int
+	Err    errors.EdgeX // set when Status is non-zero
+}
+
+// Failed reports whether this item's operation failed.
+func (result BatchItemResult) Failed() bool {
+	return result.Status != 0
+}
+
+// NewBatchItemResult converts a per-item result, reusing BaseResult.Error so a failure
+// carries the same error kind as the equivalent single-item operation.
+func NewBatchItemResult(name string, result BaseResult) BatchItemResult {
+	return BatchItemResult{
+		Name:   name,
+		Status: result.Status,
+		Err:    result.Error(),
+	}
+}

--- a/pkg/xrtmodels/response_test.go
+++ b/pkg/xrtmodels/response_test.go
@@ -36,3 +36,24 @@ func TestScheduleReadResponse_Unmarshal(t *testing.T) {
 	assert.Equal(t, "s1", resp.Result.Schedule.Name)
 	assert.Equal(t, "d1", resp.Result.Schedule.Device)
 }
+
+// Batch add and delete report per-item status while the envelope stays successful, so a
+// failed item must always carry an error — treating one as success would report a failure
+// as done.
+func TestNewBatchItemResult(t *testing.T) {
+	t.Run("every non-zero status carries an error", func(t *testing.T) {
+		// Includes codes BaseResult has no specific mapping for.
+		for _, status := range []int{1, 3, 6, 7, 10, 13, 500, 9999} {
+			result := NewBatchItemResult("dev-1", BaseResult{Status: status, ErrorMessage: "something went wrong"})
+			assert.True(t, result.Failed(), "status %d", status)
+			assert.Error(t, result.Err, "status %d", status)
+		}
+	})
+
+	t.Run("a zero status carries no error", func(t *testing.T) {
+		result := NewBatchItemResult("dev-1", BaseResult{})
+		assert.False(t, result.Failed())
+		assert.NoError(t, result.Err)
+		assert.Equal(t, "dev-1", result.Name)
+	})
+}


### PR DESCRIPTION
- Add the six batch operation constants
- Add the batch request and response types for devices and schedules